### PR TITLE
Update base image of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Ubuntu 20.04 LTS runner will be removed on 2025-04-15, so they do not work anymore

I recognized this in #28 so I created a PR to check whether the CI works still on Ubuntu 22.04. if not I will have a look into it